### PR TITLE
docs: typo in docs/CloneSetup.md from repo to repository

### DIFF
--- a/docs/CloneSetup.md
+++ b/docs/CloneSetup.md
@@ -11,24 +11,24 @@
 
 ## Forking 🍴
 
-- There will be a `Fork` button on the top right corner of the repo. Click on it.
+- There will be a `Fork` button on the top right corner of the repository. Click on it.
 - **Uncheck** the option which says `Copy the main branch only`. 
-- This is important as we have multiple branches in the repo and `beta` is the development branch.
+- This is important as we have multiple branches in the repository and `beta` is the development branch.
 
 ## Cloning 🌀
 
-- After the fork is done, you will be redirected to your forked repo.
-- The next step is to clone the repo to your local storage.
+- After the fork is done, you will be redirected to your forked repository.
+- The next step is to clone the repository to your local storage.
 - Open your terminal and enter the following command and hit enter.
 
 ```shell
 git clone https://github.com/MilanCommunity/Milan.git
 ```
-- This will clone the repo to your local storage and you can start working on it.
+- This will clone the repository to your local storage and you can start working on it.
 
 ## Next steps 🚀
 
-So now you have the repo in your local storage. The next step is to setup the frontend and backend locally. You can refer to the following links to setup the frontend and backend locally.
+So now you have the repository in your local storage. The next step is to setup the frontend and backend locally. You can refer to the following links to setup the frontend and backend locally.
 
 1. [Setting up frontend locally](/docs/FrontendSetup.md)
 2. [Setting up the backend locally](/docs/BackendSetup.md)


### PR DESCRIPTION
<!--- THESE ARE COMMENTS, AND WON'T BE VISIBLE, DON'T WORRY 

🔴🔴🔴 PLEASE USE PROPER PR TITLE, IT'S SUPER IMPORTANT 
🔴🔴🔴 ALL LOWER CASE CHARACTERS ONLY 

EXAMPLES👇🏻👇🏻  

feat: added new footer links
fix: changes to the buggy buttons
docs: upgrades to the readme file
chore(deps): bumping up the dependencies
chore(refactor): refactored legacy codes for server

🔴🔴🔴 MAKE SURE YOU FOLLOW THESE !  -->


<!--- ADD YOUR ISSUE NUMBER LIKE #11 (NO SPACES BETWEEN # & ISSUE NUMBER) -->

closes #1162 

### 👷🏻 Changes made  
<!--- A clear and concise (minimum 2 line) description of what you have done to successfully close your assigned issue.--->

Typo in ```docs/CloneSetup.md```


changed ```repo``` to ```repository```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated terminology in the forking and cloning guide, replacing "repo" with "repository" for clarity. No changes to the actual instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->