### PR TITLE
fix: solved Link button to GitHub Repo

### DIFF
--- a/src/components/private/infoBanner/Landing.jsx
+++ b/src/components/private/infoBanner/Landing.jsx
@@ -57,10 +57,16 @@ const Landing = () => {
             </defs>
           </svg>
           <span>
-            {" "}
-            {windowWidth > 430
-              ? "We are OpenSource, you can contribute too!"
-              : "We are OpenSource"}{" "}
+            <a
+              href="https://github.com/milancommunity/Milan"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {" "}
+              {windowWidth > 430
+                ? "We are OpenSource, you can contribute too!"
+                : "We are OpenSource"}{" "}
+            </a>
           </span>
         </div>
 

--- a/src/components/private/landing/Landing.css
+++ b/src/components/private/landing/Landing.css
@@ -42,6 +42,10 @@
   transition: all 0.2s ease-in-out;
   border: 1px solid var(--headsup-stroke, rgb(215, 86, 54));
 }
+.landing_promo > span > a {
+  text-decoration: none; 
+  color: black;
+}
 
 .landing_parent > h1 {
   color: var(--Brand-brand-900, #6b2615);
@@ -53,6 +57,7 @@
   font-weight: 800;
   text-transform: capitalize;
   z-index: 3;
+  
 }
 
 .landing_parent > h1 > span {

--- a/src/components/private/landing/Landing.jsx
+++ b/src/components/private/landing/Landing.jsx
@@ -57,10 +57,16 @@ const Landing = () => {
             </defs>
           </svg>
           <span>
-            {" "}
-            {windowWidth > 430
-              ? "We are OpenSource, you can contribute too!"
-              : "We are OpenSource"}{" "}
+            <a
+              href="https://github.com/milancommunity/Milan"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {" "}
+              {windowWidth > 430
+                ? "We are OpenSource, you can contribute too!"
+                : "We are OpenSource"}{" "}
+            </a>
           </span>
         </div>
 


### PR DESCRIPTION
Bug  #1213 

Solution:
- A link can be added to the landing sections button so that on clicking it we can go to the GitHub page.

![milan](https://github.com/milancommunity/Milan/assets/65008142/fcadcfb8-820b-44c0-9826-71dcf4284177)

Browser 🥦
Google Chrome

Checklist ✅

- [x]  I checked and didn't find similar issue
- [x]  I have read the Contributing Guidelines
- [ ]  I am participating in JWOC
- [ ]  I am participating in IWOC
- [ ]  I am willing to work on this issue (blank for no).